### PR TITLE
Add id support for ingredient path lookup

### DIFF
--- a/js/items-core.js
+++ b/js/items-core.js
@@ -70,8 +70,8 @@ export function findIngredientByPath(ings, pathArr) {
   let current = ings;
   let ing = null;
   for (let i = 0; i < pathArr.length; i++) {
-    const uid = pathArr[i];
-    ing = (current || []).find(n => String(n._uid) === String(uid));
+    const val = pathArr[i];
+    ing = (current || []).find(n => String(n._uid) === String(val) || String(n.id) === String(val));
     if (!ing) return null;
     current = ing.children;
   }


### PR DESCRIPTION
## Summary
- allow `findIngredientByPath` to match by `_uid` or by `id`

## Testing
- `node - <<'NODE'
import { findIngredientByPath } from './js/items-core.js';
const tree=[{id:1,_uid:'a',children:[{id:2,_uid:'b',children:[]}]}];
console.log('uid path:',findIngredientByPath(tree,['a','b']).id);
console.log('id path:',findIngredientByPath(tree,[1,2]).id);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687d6d5fcda48328bb54c4f2afab0f48