### PR TITLE
Fix unit price display for non-craftables

### DIFF
--- a/js/item-ui.js
+++ b/js/item-ui.js
@@ -112,7 +112,7 @@ function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentE
             // Nodos hoja (sin hijos) ocultan todo, salvo casos anteriores ya tratados
             (!hideTotals ? `
               <div>${formatGoldColored(ing.total_crafted || ing.total_buy)}</div>
-              <div class="item-solo-precio">${ing.is_craftable ? formatGoldColored(craftedPriceSafe) : formatGoldColored(ing.buy_price)} <span style="color: #c99b5b">c/u</span></div>
+              <div class="item-solo-precio">${ing.is_craftable ? formatGoldColored(craftedPriceSafe) : formatGoldColored(0)} <span style="color: #c99b5b">c/u</span></div>
               ${parentId !== null && nivel > 0 ? `<input type="radio" name="mode-${ing._uid}" class="chk-mode-crafted" data-uid="${ing._uid}" ${ing.modeForParentCrafted === 'crafted' ? 'checked' : ''} title="Usar precio de crafteo para el padre">` : ''}
             ` :
               ``


### PR DESCRIPTION
## Summary
- update unit price formatting for non-craftable items to show `0`

## Testing
- `node - <<'NODE'
  global.window = {};
  const {formatGoldColored} = require('./js/bundle-utils-1.js');
  const ing = {is_craftable: false, buy_price: 123};
  const craftedPriceSafe = 999;
  const html = `<div class="item-solo-precio">${ing.is_craftable ? formatGoldColored(craftedPriceSafe) : formatGoldColored(0)} <span style="color: #c99b5b">c/u</span></div>`;
  console.log(html);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687d8cd1a6dc83288758614509c69fc7