### PR TITLE
Fix global price vars for comparison

### DIFF
--- a/js/compare-ui.js
+++ b/js/compare-ui.js
@@ -331,10 +331,10 @@ function renderCraftingSectionUI() {
   // --- DEBUG: Mostrar todos los valores clave ---
 
   // Obtener output_item_count de la receta principal
-  const outputCount = (_mainRecipeOutputCount && !isNaN(_mainRecipeOutputCount)) ? _mainRecipeOutputCount : 1;
+  const outputCount = (window._mainRecipeOutputCount && !isNaN(window._mainRecipeOutputCount)) ? window._mainRecipeOutputCount : 1;
   const totals = getTotals(window.ingredientObjs);
   const qtyValue = (typeof getQtyInputValue() !== 'undefined' ? getQtyInputValue() : window.globalQty);
-  const precioCompraTotal = (_mainBuyPrice != null) ? _mainBuyPrice * window.globalQty : 0;
+  const precioCompraTotal = (window._mainBuyPrice != null) ? window._mainBuyPrice * window.globalQty : 0;
   // Suma el sell_price de todos los ítems raíz
   const totalSellPrice = window.ingredientObjs.reduce((sum, ing) => sum + (Number(ing.sell_price) || 0), 0);
   const precioVentaTotal = totalSellPrice * window.globalQty;
@@ -361,7 +361,7 @@ function renderCraftingSectionUI() {
   const profitSellTotal = ventaTrasComisionTotal - totals.totalSell;
   const profitCraftedTotal = ventaTrasComisionTotal - totals.totalCrafted;
   // Variables para profit por unidad (outputCount > 1)
-  const precioVentaUnidadMercado = (_mainSellPrice != null) ? _mainSellPrice : 0;
+  const precioVentaUnidadMercado = (window._mainSellPrice != null) ? window._mainSellPrice : 0;
   const ventaTrasComisionUnidadMercado = precioVentaUnidadMercado - (precioVentaUnidadMercado * 0.15);
   const profitBuyUnidadMercado = ventaTrasComisionUnidadMercado - (totals.totalBuy / outputCount);
   const profitSellUnidadMercado = ventaTrasComisionUnidadMercado - (totals.totalSell / outputCount);
@@ -439,8 +439,8 @@ function renderCraftingSectionUI() {
       </section>`;
   }
   if (outputCount > 1) {
-    const precioCompraUnidadMercado = (_mainBuyPrice != null) ? _mainBuyPrice : 0;
-    const precioVentaUnidadMercado = (_mainSellPrice != null) ? _mainSellPrice : 0;
+    const precioCompraUnidadMercado = (window._mainBuyPrice != null) ? window._mainBuyPrice : 0;
+    const precioVentaUnidadMercado = (window._mainSellPrice != null) ? window._mainSellPrice : 0;
     const precioCraftingMinUnidadReal = outputCount > 0 ? precioCraftingMinTotal / outputCount : precioCraftingMinTotal;
     const preciosUnidadCorr = [precioCompraUnidadMercado, precioVentaUnidadMercado, precioCraftingMinUnidadReal];
     const precioMinimoUnidadReal = Math.min(...preciosUnidadCorr.filter(x => x > 0));

--- a/js/items-core.js
+++ b/js/items-core.js
@@ -4,6 +4,9 @@
 if (typeof window !== 'undefined') {
   window.ingredientObjs = window.ingredientObjs || [];
   window.globalQty = window.globalQty || 1;
+  window._mainBuyPrice = window._mainBuyPrice || 0;
+  window._mainSellPrice = window._mainSellPrice || 0;
+  window._mainRecipeOutputCount = window._mainRecipeOutputCount || 1;
 }
 
 export function setIngredientObjs(val) {
@@ -380,6 +383,9 @@ window.comparativa.agregarItemPorId = async function(id) {
       let hijos = await prepareIngredientTreeData(id, recipeData);
       if (!Array.isArray(hijos)) hijos = [];
       const marketData = await fetchMarketDataForItem(id);
+      window._mainBuyPrice = marketData.buy_price || 0;
+      window._mainSellPrice = marketData.sell_price || 0;
+      window._mainRecipeOutputCount = recipeData ? (recipeData.output_item_count || 1) : 1;
       ingredientesArbol = new CraftIngredient({
         id: itemData.id,
         name: itemData.name,
@@ -395,6 +401,9 @@ window.comparativa.agregarItemPorId = async function(id) {
       ingredientesArbol.recalc(window.globalQty || 1, null);
     } else {
       const marketData = await fetchMarketDataForItem(id);
+      window._mainBuyPrice = marketData.buy_price || 0;
+      window._mainSellPrice = marketData.sell_price || 0;
+      window._mainRecipeOutputCount = 1;
       ingredientesArbol = new CraftIngredient({
         id: itemData.id,
         name: itemData.name,


### PR DESCRIPTION
## Summary
- initialize extra price and recipe globals
- update globals when adding comparison items
- use window namespace for main price variables in compare-ui

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687d9636fe0c832892981de481467ca6