### PR TITLE
Fix crafted total fallback

### DIFF
--- a/js/item-ui.js
+++ b/js/item-ui.js
@@ -111,7 +111,7 @@ function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentE
             ` :
             // Nodos hoja (sin hijos) ocultan todo, salvo casos anteriores ya tratados
             (!hideTotals ? `
-              <div>${formatGoldColored(ing.total_crafted || ing.total_buy)}</div>
+              <div>${formatGoldColored(ing.total_crafted ?? 0)}</div>
               <div class="item-solo-precio">${ing.is_craftable ? formatGoldColored(craftedPriceSafe) : formatGoldColored(0)} <span style="color: #c99b5b">c/u</span></div>
               ${parentId !== null && nivel > 0 ? `<input type="radio" name="mode-${ing._uid}" class="chk-mode-crafted" data-uid="${ing._uid}" ${ing.modeForParentCrafted === 'crafted' ? 'checked' : ''} title="Usar precio de crafteo para el padre">` : ''}
             ` :


### PR DESCRIPTION
## Summary
- show crafted total as `0` when an ingredient lacks crafting info

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d9c0a35248328983be6ac1220a6d3