### PR TITLE
Update UI to show 0 for crafted prices

### DIFF
--- a/js/compare-ui.js
+++ b/js/compare-ui.js
@@ -191,7 +191,7 @@ function renderMainItemRow(mainItem, qty, totalBuy, totalSell, totalCrafted) {
       <td class="item-unit-sell">${formatGoldColored(Number(mainItem.sell_price))} <span style="color: #c99b5b">c/u</span></td>
       <td class="item-solo-buy"><div>${formatGoldColored(realTotals.totalBuy)}</div></td>
       <td class="item-solo-sell"><div>${formatGoldColored(realTotals.totalSell)}</div></td>
-      <td class="item-solo-crafted"><div>${formatGoldColored(realTotals.totalCrafted)}</div></td>
+      <td class="item-solo-crafted"><div>${formatGoldColored(0)}</div></td>
       <td class="item-profit">${(() => {
         const ventaBruta = Number(mainItem.sell_price) * qty;
         const ventaNeta = ventaBruta - (ventaBruta * 0.15);
@@ -273,7 +273,7 @@ function renderRows(ings, nivel = 0, parentId = null, rowGroupIndex = 0, parentE
         
         <td class="item-solo-crafted">
           ${(ing.is_craftable && ing.children && ing.children.length > 0 && ing.total_crafted !== null) ? `
-            <div>${formatGoldColored(ing.total_crafted)}</div>
+            <div>${formatGoldColored(0)}</div>
             <div class="item-solo-precio">${formatGoldColored(0)} <span style="color: #c99b5b">c/u</span></div>
             ${radiosCrafted}` : ''
           }

--- a/js/item-ui.js
+++ b/js/item-ui.js
@@ -159,7 +159,7 @@ function renderMainItemRow(mainNode, nivel = 0) {
             <div class="item-solo-precio">${formatGoldColored(sellPriceUnit)} <span style="color: #c99b5b">c/u</span></div>
         </td>
         <td class="item-solo-craft">
-            <div>${formatGoldColored(totals.totalCrafted)}</div>
+            <div>${formatGoldColored(0)}</div>
         </td>
         <td></td>
     </tr>


### PR DESCRIPTION
## Summary
- adjust main item row in comparison table to show `0` crafted price
- adjust child rows in comparison table to show `0` crafted price
- show `0` crafted price on the single item page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d9fcc2d8c83289b799a899fb114e8