### PR TITLE
Fix market data scope for compare craft

### DIFF
--- a/js/items-core.js
+++ b/js/items-core.js
@@ -378,11 +378,12 @@ window.comparativa.agregarItemPorId = async function(id) {
     if (typeof window.showLoader === 'function') window.showLoader(true);
     const itemData = await fetchItemData(id);
     const recipeData = await fetchRecipeData(id);
+    let marketData;
     let ingredientesArbol;
     if (recipeData) {
       let hijos = await prepareIngredientTreeData(id, recipeData);
       if (!Array.isArray(hijos)) hijos = [];
-      const marketData = await fetchMarketDataForItem(id);
+      marketData = await fetchMarketDataForItem(id);
       window._mainBuyPrice = marketData.buy_price || 0;
       window._mainSellPrice = marketData.sell_price || 0;
       window._mainRecipeOutputCount = recipeData ? (recipeData.output_item_count || 1) : 1;
@@ -400,7 +401,7 @@ window.comparativa.agregarItemPorId = async function(id) {
       });
       ingredientesArbol.recalc(window.globalQty || 1, null);
     } else {
-      const marketData = await fetchMarketDataForItem(id);
+      marketData = await fetchMarketDataForItem(id);
       window._mainBuyPrice = marketData.buy_price || 0;
       window._mainSellPrice = marketData.sell_price || 0;
       window._mainRecipeOutputCount = 1;


### PR DESCRIPTION
## Summary
- ensure `marketData` is declared outside the recipe conditional in `agregarItemPorId`
- keep per-unit price rendering using the fetched market data

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687dae9f808c8328b27bfea759a20490