### PR TITLE
Fix craft price fallbacks

### DIFF
--- a/js/compare-ui.js
+++ b/js/compare-ui.js
@@ -323,6 +323,8 @@ function updateQtyInputVisibility(show) {
 
 // --- Renderizado de la sección 7: Ingredientes para craftear ---
 function renderCraftingSectionUI(buyPrice = window._mainBuyPrice, sellPrice = window._mainSellPrice) {
+  if (buyPrice == null) buyPrice = window._mainBuyPrice;
+  if (sellPrice == null) sellPrice = window._mainSellPrice;
   if (typeof window._mainItemExpanded === 'undefined') window._mainItemExpanded = false;
   
   // Mostrar/ocultar el input de cantidad global según si hay ingredientes
@@ -648,6 +650,8 @@ export async function initItemUI(itemData, marketData) {
 export { renderItemUI, safeRenderTable };
 
 function safeRenderTable(buyPrice = window._mainBuyPrice, sellPrice = window._mainSellPrice) {
+  if (buyPrice == null) buyPrice = window._mainBuyPrice;
+  if (sellPrice == null) sellPrice = window._mainSellPrice;
   // Siempre recalcula y renderiza la sección de ingredientes y totales
   recalcAll(window.ingredientObjs, window.globalQty);
   const seccion = document.getElementById('seccion-crafting');

--- a/js/items-core.js
+++ b/js/items-core.js
@@ -419,7 +419,13 @@ window.comparativa.agregarItemPorId = async function(id) {
       });
     }
     window.ingredientObjs.push(ingredientesArbol);
-    if (typeof window.safeRenderTable === 'function') window.safeRenderTable(marketData.buy_price, marketData.sell_price);
+    if (typeof window.safeRenderTable === 'function') {
+      if (typeof marketData.buy_price === 'number' && typeof marketData.sell_price === 'number') {
+        window.safeRenderTable(marketData.buy_price, marketData.sell_price);
+      } else {
+        window.safeRenderTable();
+      }
+    }
     if (typeof window.showLoader === 'function') window.showLoader(false);
   } catch (e) {
     if (typeof window.showLoader === 'function') window.showLoader(false);


### PR DESCRIPTION
## Summary
- ensure buy/sell price params fallback to globals when missing
- only forward valid prices when rerendering comparison view

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687db644dea88328a8ce81a56c565ce6