### PR TITLE
Fix compare crafting totals

### DIFF
--- a/js/compare-ui.js
+++ b/js/compare-ui.js
@@ -393,7 +393,7 @@ function renderCraftingSectionUI(buyPrice = window._mainBuyPrice, sellPrice = wi
           <th><div class="tooltip-modern">Total Crafted
             <span class="tooltiptext-modern">Suma total si CRAFTEAS todos los materiales posibles desde cero.</span>
           </div></th>
-          <td class="item-solo-crafted">${formatGoldColored(0)}</td>
+          <td class="item-solo-crafted">${formatGoldColored(totals.totalCrafted)}</td>
         </tr>
       </table>
     </div>
@@ -416,7 +416,7 @@ function renderCraftingSectionUI(buyPrice = window._mainBuyPrice, sellPrice = wi
             <th><div class="tooltip-modern">Total Crafted
               <span class="tooltiptext-modern">Suma total si CRAFTEAS todos los materiales posibles desde cero.</span>
             </div></th>
-            <td class="item-solo-crafted">${formatGoldColored(0)}</td>
+              <td class="item-solo-crafted">${formatGoldColored(totals.totalCrafted / outputCount)}</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- restore crafted totals in compare view tables

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687db7d2a0e4832885a770b89bee7cfc