### PR TITLE
Set global market price globals before rendering item

### DIFF
--- a/js/item-loader.js
+++ b/js/item-loader.js
@@ -24,6 +24,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     const recipeData = await fetchRecipeData(itemId);
     const marketData = await fetchMarketDataForItem(itemId);
 
+    // Valores globales para comparativas y tablas
+    window._mainBuyPrice = marketData.buy_price || 0;
+    window._mainSellPrice = marketData.sell_price || 0;
+    window._mainRecipeOutputCount = recipeData ? (recipeData.output_item_count || 1) : 1;
+
     let rootIngredient;
 
     if (recipeData) {


### PR DESCRIPTION
## Summary
- set global variables for main item prices and output count in `item-loader.js`
- ensures per-unit comparison uses correct values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dca8a603c8328b6a7ffac0fe2a10d