### PR TITLE
Fix fractales-gold imports

### DIFF
--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -178,7 +178,18 @@
     });
   </script>
   <script type="module">
-    import { renderGraficoContribuciones, renderGraficoAbrirVsVender, renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaResumenOroIndividual, renderTablaReferenciasProfit, renderExtras, fetchItemPrices, fetchIconsFor, ICON_ID_MAP } from './js/fractales-gold-ui.js';
+    import {
+      renderGraficoContribuciones,
+      renderGraficoAbrirVsVender,
+      renderTablaPrecios,
+      renderTablaPromedios,
+      renderTablaResumenOro,
+      renderTablaResumenOroIndividual,
+      renderTablaReferenciasProfit,
+      renderExtras,
+      ICON_ID_MAP
+    } from './js/fractales-gold-ui.js';
+    import { fetchItemPrices, fetchIconsFor } from './js/fractales-utils.js';
 
     async function fetchPreciosFractales() {
       const priceMap = await fetchItemPrices([75919, 73248]);


### PR DESCRIPTION
## Summary
- load `fetchItemPrices` and `fetchIconsFor` directly from `fractales-utils.js`
- adjust imports in `fractales-gold.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eb81f14008328b95c033ed3ef7caa