### PR TITLE
Add bundle-legendary export modules

### DIFF
--- a/dones.html
+++ b/dones.html
@@ -78,6 +78,7 @@
 
   <script src="js/bundle-utils-1.js"></script>
   <script src="js/bundle-dones.js"></script>
+  <script src="js/bundle-legendary.js"></script>
   <script src="js/dones.js"></script>
   <script src="js/bundle-auth-nav.js"></script>
   <script>

--- a/js/bundle-legendary.js
+++ b/js/bundle-legendary.js
@@ -3396,3 +3396,7 @@ window.appThirdGen = new LegendaryCraftingBase({
     itemNameInput: 'itemNameThird'
   }
 });
+
+// Expose legendary items data globally for other modules
+window.LEGENDARY_ITEMS = LEGENDARY_ITEMS;
+window.LEGENDARY_ITEMS_3GEN = LEGENDARY_ITEMS_3GEN;

--- a/js/data/legendaryItems1gen.js
+++ b/js/data/legendaryItems1gen.js
@@ -1,0 +1,2 @@
+export const LEGENDARY_ITEMS = window.LEGENDARY_ITEMS;
+export default LEGENDARY_ITEMS;

--- a/js/data/legendaryItems3gen.js
+++ b/js/data/legendaryItems3gen.js
@@ -1,0 +1,2 @@
+export const LEGENDARY_ITEMS_3GEN = window.LEGENDARY_ITEMS_3GEN;
+export default LEGENDARY_ITEMS_3GEN;


### PR DESCRIPTION
## Summary
- expose `LEGENDARY_ITEMS` and `LEGENDARY_ITEMS_3GEN` on `window`
- add JS modules exporting these global objects
- load `bundle-legendary.js` for dones page

## Testing
- `node -e "global.window={LEGENDARY_ITEMS:{a:1},LEGENDARY_ITEMS_3GEN:{b:2}}; import('./js/data/legendaryItems1gen.js').then(m=>{console.log('1gen',m.LEGENDARY_ITEMS);return import('./js/data/legendaryItems3gen.js')}).then(m=>console.log('3gen',m.LEGENDARY_ITEMS_3GEN));"`
- `python3 -m http.server 8000 &` and `curl -sI http://localhost:8000/dones.html`, `curl -sI http://localhost:8000/js/bundle-legendary.js`

------
https://chatgpt.com/codex/tasks/task_e_687eed141b548328b84f60a1bb18d0f2