### PR TITLE
Expose legendary data globally

### DIFF
--- a/js/bundle-legendary.js
+++ b/js/bundle-legendary.js
@@ -3400,3 +3400,4 @@ window.appThirdGen = new LegendaryCraftingBase({
 // Expose legendary items data globally for other modules
 window.LEGENDARY_ITEMS = LEGENDARY_ITEMS;
 window.LEGENDARY_ITEMS_3GEN = LEGENDARY_ITEMS_3GEN;
+window.LegendaryData = { LEGENDARY_ITEMS, LEGENDARY_ITEMS_3GEN };

--- a/js/data/legendaryItems1gen.js
+++ b/js/data/legendaryItems1gen.js
@@ -1,2 +1,0 @@
-export const LEGENDARY_ITEMS = window.LEGENDARY_ITEMS;
-export default LEGENDARY_ITEMS;

--- a/js/data/legendaryItems3gen.js
+++ b/js/data/legendaryItems3gen.js
@@ -1,2 +1,0 @@
-export const LEGENDARY_ITEMS_3GEN = window.LEGENDARY_ITEMS_3GEN;
-export default LEGENDARY_ITEMS_3GEN;

--- a/js/dones.js
+++ b/js/dones.js
@@ -201,7 +201,7 @@ async function renderDon(don, container) {
 
 // === Dones de armas legendarias Gen 1 ===
 async function extractWeaponGifts() {
-  const { LEGENDARY_ITEMS } = await import('./data/legendaryItems1gen.js');
+  const { LEGENDARY_ITEMS } = window.LegendaryData || {};
   const gifts = [];
   const seen = new Set();
   for (const item of Object.values(LEGENDARY_ITEMS)) {
@@ -301,10 +301,9 @@ async function renderSpecialDons() {
   loader.style.display = 'none';
 }
 
-// === Tributo Dracónico (dinámico desde legendaryItems3gen) ===
+// === Tributo Dracónico ===
 async function getDraconicTribute() {
-  // Carga perezosa para evitar coste inicial si el usuario no abre la pestaña
-  const { LEGENDARY_ITEMS_3GEN } = await import('./data/legendaryItems3gen.js');
+  const { LEGENDARY_ITEMS_3GEN } = window.LegendaryData || {};
   for (const weapon of Object.values(LEGENDARY_ITEMS_3GEN)) {
     const tribute = weapon.components?.find(c => {
       const nm = c.name?.toLowerCase() || '';


### PR DESCRIPTION
## Summary
- delete unused `js/data` exports
- expose `window.LegendaryData` inside `bundle-legendary.js`
- swap dynamic imports for `window.LegendaryData` in `dones.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687eeff0e8248328a83176681a7897a8