### PR TITLE
Add rollup build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gw2-project",
+  "private": true,
+  "scripts": {
+    "build": "rollup -c"
+  },
+  "devDependencies": {
+    "rollup": "^4.16.0",
+    "@rollup/plugin-terser": "^0.4.4",
+    "rollup-plugin-multi-input": "^1.3.1"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+import multiInput from 'rollup-plugin-multi-input';
+import { terser } from '@rollup/plugin-terser';
+
+export default {
+  input: 'js/*.js',
+  plugins: [
+    multiInput(),
+    terser()
+  ],
+  output: {
+    dir: 'dist',
+    format: 'iife',
+    entryFileNames: '[name].min.js'
+  }
+};


### PR DESCRIPTION
## Summary
- setup `package.json` with dev dependencies for Rollup
- configure Rollup in `rollup.config.js`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: rollup command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd189908483289870afa9354d0555