### PR TITLE
Fix comparativa removal check

### DIFF
--- a/dist/cuenta.min.js
+++ b/dist/cuenta.min.js
@@ -249,7 +249,7 @@ function loadAndDisplayComparativas() {
 
     comparativas.forEach((comp, idx) => {
         const listItem = document.createElement('li');
-        listItem.className = 'favorito-item';
+        listItem.className = 'favorito-item comparativa-item';
 
         // Ícono
         const icon = document.createElement('span');

--- a/src/js/cuenta.js
+++ b/src/js/cuenta.js
@@ -249,7 +249,7 @@ function loadAndDisplayComparativas() {
 
     comparativas.forEach((comp, idx) => {
         const listItem = document.createElement('li');
-        listItem.className = 'favorito-item';
+        listItem.className = 'favorito-item comparativa-item';
 
         // Ícono
         const icon = document.createElement('span');


### PR DESCRIPTION
## Summary
- add `comparativa-item` class when rendering saved comparisons
- keep the class list unchanged for favorite items

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880403386b483289fe40c9576a0a69f