### PR TITLE
Enable auto loading comparison items

### DIFF
--- a/compare-craft.html
+++ b/compare-craft.html
@@ -140,5 +140,13 @@
 <script src="dist/storageUtils.min.js"></script>
 <!-- Manejadores de comparativa (guardar comparativa) -->
 <script src="dist/compareHandlers.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    if (window.comparativa &&
+        typeof window.comparativa.loadComparativaFromURL === 'function') {
+      window.comparativa.loadComparativaFromURL();
+    }
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- auto-load comparison items based on `ids` query param

## Testing
- `npm run build` *(fails: `rollup` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804841695883289b2d73833ad4082c