### PR TITLE
Fix unit prices respecting global quantity

### DIFF
--- a/dist/item-ui.min.js
+++ b/dist/item-ui.min.js
@@ -397,8 +397,8 @@ const precioVentaTotal = mainNode && typeof mainNode.sell_price === 'number' ? m
   }
   if (outputCount > 1) {
     const globalQty = window.globalQty || 1;
-    const precioCompraUnidadMercado = (_mainBuyPrice != null) ? (_mainBuyPrice * globalQty) / outputCount : 0;
-    const precioVentaUnidadMercado = (_mainSellPrice != null) ? (_mainSellPrice * globalQty) / outputCount : 0;
+    const precioCompraUnidadMercado = (_mainBuyPrice != null) ? _mainBuyPrice * globalQty : 0;
+    const precioVentaUnidadMercado = (_mainSellPrice != null) ? _mainSellPrice * globalQty : 0;
     const precioCraftingMinUnidadReal = outputCount > 0 ? precioCraftingMinTotal / outputCount : precioCraftingMinTotal;
     const preciosUnidadCorr = [precioCompraUnidadMercado, precioVentaUnidadMercado, precioCraftingMinUnidadReal];
     const precioMinimoUnidadReal = Math.min(...preciosUnidadCorr.filter(x => x > 0));

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -397,8 +397,8 @@ const precioVentaTotal = mainNode && typeof mainNode.sell_price === 'number' ? m
   }
   if (outputCount > 1) {
     const globalQty = window.globalQty || 1;
-    const precioCompraUnidadMercado = (_mainBuyPrice != null) ? (_mainBuyPrice * globalQty) / outputCount : 0;
-    const precioVentaUnidadMercado = (_mainSellPrice != null) ? (_mainSellPrice * globalQty) / outputCount : 0;
+    const precioCompraUnidadMercado = (_mainBuyPrice != null) ? _mainBuyPrice * globalQty : 0;
+    const precioVentaUnidadMercado = (_mainSellPrice != null) ? _mainSellPrice * globalQty : 0;
     const precioCraftingMinUnidadReal = outputCount > 0 ? precioCraftingMinTotal / outputCount : precioCraftingMinTotal;
     const preciosUnidadCorr = [precioCompraUnidadMercado, precioVentaUnidadMercado, precioCraftingMinUnidadReal];
     const precioMinimoUnidadReal = Math.min(...preciosUnidadCorr.filter(x => x > 0));


### PR DESCRIPTION
## Summary
- factor `globalQty` into market unit price calculations for multi-output recipes
- keep distribution bundle in sync

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805745cc808328ae9b82fd267ef78e