### PR TITLE
Fix piedra check in market exclusion

### DIFF
--- a/dist/bundle-legendary.min.js
+++ b/dist/bundle-legendary.min.js
@@ -950,7 +950,7 @@ async function createIngredientTree3(itemData, parent = null) {
       if (lowerName.includes('esquirla') && id !== 70820) return true;
       if (lowerName.includes('trébol')) return true;
       if (lowerName.includes('trebol')) return true;
-      if (lowerName.includes('piedra')) return true;
+      if (lowerName.includes('piedra rúnica')) return true;
       if (lowerName.includes('bendición')) return true;
       if (lowerName.includes('tributo')) return true;
       if (lowerName.includes('esencia')) return true;

--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -950,7 +950,8 @@ async function createIngredientTree3(itemData, parent = null) {
       if (lowerName.includes('esquirla') && id !== 70820) return true;
       if (lowerName.includes('trébol')) return true;
       if (lowerName.includes('trebol')) return true;
-      if (lowerName.includes('piedra')) return true;
+      // Las piedras suelen ser comerciables; solo excluir las rúnicas
+      if (lowerName.includes('piedra rúnica')) return true;
       if (lowerName.includes('bendición')) return true;
       if (lowerName.includes('tributo')) return true;
       if (lowerName.includes('esencia')) return true;


### PR DESCRIPTION
## Summary
- narrow "piedra" filter to only exclude runestones for 3rd gen legendary items
- mirror the change in the minified bundle

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_688063cb71948328bc86a6be84dca1dc