### PR TITLE
Fix battle gift keyword

### DIFF
--- a/dist/bundle-legendary.min.js
+++ b/dist/bundle-legendary.min.js
@@ -3333,7 +3333,7 @@ const quickLoadButtons1 = {
 // Mensajes personalizados para ítems sin precio en el mercado
 const customPriceTexts1 = [
   { name: 'Don de la exploración', display: 'Recompensa por completar mapas', keywords: ['exploraci'] },
-  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['batalla'] },
+  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['don de la batalla'] },
   { name: 'Esquirla de hematites', display: 'Se compra en la forja mística', keywords: ['hematites'] },
   { name: 'Esquirla de obsidiana', display: 'Se compra por karma con NPC', keywords: ['obsidiana'] }
 ];
@@ -3374,7 +3374,7 @@ const quickLoadButtons3 = {
 
 const customPriceTexts3 = [
   { name: 'Don de la exploración', display: 'Recompensa por completar mapas', keywords: ['exploraci'] },
-  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['batalla'] },
+  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['don de la batalla'] },
   { name: 'Esquirla de hematites', display: 'Se compra en la forja mística', keywords: ['hematites'] },
   { name: 'Esquirla de obsidiana', display: 'Se compra por karma con NPC', keywords: ['obsidiana'] }
 ];

--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -3334,7 +3334,7 @@ const quickLoadButtons1 = {
 // Mensajes personalizados para ítems sin precio en el mercado
 const customPriceTexts1 = [
   { name: 'Don de la exploración', display: 'Recompensa por completar mapas', keywords: ['exploraci'] },
-  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['batalla'] },
+  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['don de la batalla'] },
   { name: 'Esquirla de hematites', display: 'Se compra en la forja mística', keywords: ['hematites'] },
   { name: 'Esquirla de obsidiana', display: 'Se compra por karma con NPC', keywords: ['obsidiana'] }
 ];
@@ -3375,7 +3375,7 @@ const quickLoadButtons3 = {
 
 const customPriceTexts3 = [
   { name: 'Don de la exploración', display: 'Recompensa por completar mapas', keywords: ['exploraci'] },
-  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['batalla'] },
+  { name: 'Don de la batalla', display: 'Recompensa por completar la ruta del don de la batalla en WvW', keywords: ['don de la batalla'] },
   { name: 'Esquirla de hematites', display: 'Se compra en la forja mística', keywords: ['hematites'] },
   { name: 'Esquirla de obsidiana', display: 'Se compra por karma con NPC', keywords: ['obsidiana'] }
 ];


### PR DESCRIPTION
## Summary
- narrow keywords for "Don de la batalla" in legendary bundles

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_688071fb30648328afb39dbad9cca1c8