### PR TITLE
Modulariza buscador en modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         const closeBtn = document.getElementById('close-search-modal');
         openBtn.addEventListener('click', function(e) {
           e.preventDefault();
-          openSearchModal();
+          openSearchModal('dist/search-modal.min.js');
         });
         closeBtn.addEventListener('click', closeSearchModal);
         modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);

--- a/item.html
+++ b/item.html
@@ -84,7 +84,7 @@
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      openSearchModal();
+      openSearchModal('dist/search-modal.min.js');
     });
     closeBtn.addEventListener('click', closeSearchModal);
     modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);

--- a/src/js/search-modal-compare-craft.js
+++ b/src/js/search-modal-compare-craft.js
@@ -1,148 +1,25 @@
 // search-modal-compare-craft.js
-// Modal de búsqueda exclusivo para compare-craft.html
-// No interfiere con otros modales ni con search-modal.js global
+// Configura el modal de búsqueda para compare-craft.html utilizando search-modal-core
 
-
-const API_URL_JSON = 'https://api.datawars2.ie/gw2/v1/items/json?fields=id,name_es';
-const API_URL_CSV = 'https://api.datawars2.ie/gw2/v1/items/csv?fields=buy_price,sell_price,buy_quantity,sell_quantity,last_updated,1d_buy_sold,1d_sell_sold,2d_buy_sold,2d_sell_sold,7d_buy_sold,7d_sell_sold,1m_buy_sold,1m_sell_sold';
-const GW2_API_ITEMS = 'https://api.guildwars2.com/v2/items?ids=';
-
-const searchInput = document.getElementById('modal-search-input');
-const suggestionsEl = document.getElementById('modal-suggestions');
-const resultsEl = document.getElementById('modal-results');
-const loader = document.getElementById('modal-loader');
-const errorMessage = document.getElementById('modal-error-message');
-
-let allItems = [];
-let iconCache = {};
-let rarityCache = {};
-
-function showLoader(show) {
-  loader.style.display = show ? 'block' : 'none';
-}
-function showError(msg) {
-  errorMessage.textContent = msg;
-  errorMessage.style.display = 'block';
-}
-function hideError() {
-  errorMessage.style.display = 'none';
-}
-
-async function fetchAllItems() {
-  const cached = sessionStorage.getItem('itemList');
-  if (cached) {
-    allItems = JSON.parse(cached);
-    return;
-  }
-  showLoader(true);
-  hideError();
-  try {
-    const resJson = await fetch(API_URL_JSON);
-    const itemsJson = await resJson.json();
-    const resCsv = await fetch(API_URL_CSV);
-    const csvText = await resCsv.text();
-    const lines = csvText.trim().split('\n');
-    const headers = lines[0].split(',');
-    const itemsCsv = lines.slice(1).map(line => {
-      const values = line.split(',');
-      const obj = {};
-      headers.forEach((h, i) => {
-        if (h === 'last_updated') {
-          obj[h] = values[i] || '-';
-        } else if (h === 'buy_price' || h === 'sell_price') {
-          obj[h] = values[i] !== '' ? parseInt(values[i], 10) : null;
-        } else {
-          obj[h] = values[i] !== '' ? parseInt(values[i], 10) : null;
-        }
+(function() {
+  function start() {
+    if (typeof initSearchModal === 'function') {
+      initSearchModal({
+        onSelect: function(id, e) {
+          if (window.selectItem) window.selectItem(id, e);
+        },
+        formatPrice: function(v) { return v || 0; },
+        useSuggestions: false
       });
-      return obj;
-    });
-    const csvById = {};
-    itemsCsv.forEach(item => { csvById[Number(item.id)] = item; });
-    allItems = itemsJson.map(item => ({
-      ...item,
-      ...(csvById[Number(item.id)] || {})
-    }));
-    sessionStorage.setItem('itemList', JSON.stringify(allItems));
-  } catch (e) {
-    showError('No se pudieron cargar los ítems.');
-  } finally {
-    showLoader(false);
+    }
   }
-}
 
-function renderResults(items, showNoResults = false) {
-  resultsEl.innerHTML = '';
-  if (!items.length && showNoResults) {
-    resultsEl.innerHTML = '<div class="error-message">No se encontraron ítems.</div>';
-    return;
+  if (typeof initSearchModal === 'undefined') {
+    var script = document.createElement('script');
+    script.src = 'dist/search-modal-core.min.js';
+    script.onload = start;
+    document.body.appendChild(script);
+  } else {
+    start();
   }
-  const fragment = document.createDocumentFragment();
-  items.forEach(item => {
-    const card = document.createElement('div');
-    card.className = 'item-card';
-    card.onclick = (event) => window.selectItem(item.id, event);
-    const rarityClass = typeof getRarityClass === 'function'
-        ? getRarityClass(rarityCache[item.id])
-        : '';
-    card.innerHTML = `
-      <img src="${iconCache[item.id] || ''}" alt=""/>
-      <div class="item-name ${rarityClass}">${item.name_es}</div>
-      <div class="item-price" style="display:none;">Compra: ${item.buy_price || 0} | Venta: ${item.sell_price || 0}</div>
-    `;
-    fragment.appendChild(card);
-  });
-  resultsEl.appendChild(fragment);
-}
-
-function debounce(fn, ms) {
-  let timer;
-  return function(...args) {
-    clearTimeout(timer);
-    timer = setTimeout(() => fn.apply(this, args), ms);
-  };
-}
-
-async function fetchIconsFor(ids) {
-  if (!ids.length) return;
-  try {
-    const res = await fetch(GW2_API_ITEMS + ids.join(','));
-    const data = await res.json();
-    data.forEach(item => {
-      iconCache[item.id] = item.icon;
-      rarityCache[item.id] = item.rarity;
-    });
-  } catch {}
-}
-
-// Helper para eliminar acentos y normalizar
-function normalizeStr(str) {
-  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-}
-
-searchInput.addEventListener('input', debounce(async function(e) {
-  const value = this.value.trim().toLowerCase();
-  const normalValue = normalizeStr(value);
-  if (value.length < 3) {
-    resultsEl.innerHTML = '';
-    return;
-  }
-  let matches = allItems.filter(item => {
-    if (!item.name_es) return false;
-    const normalName = normalizeStr(item.name_es);
-    const match = normalName.includes(normalValue);
-    return match;
-  });
-  matches = matches.slice(0, 30);
-  if (matches.length) {
-    const ids = matches.map(i => i.id);
-    await fetchIconsFor(ids);
-  }
-  renderResults(matches, true);
-}, 250));
-
-// Inicialización automática al abrir modal
-if (!window._compareCraftSearchLoaded) {
-  fetchAllItems();
-  window._compareCraftSearchLoaded = true;
-}
+})();

--- a/src/js/search-modal-core.js
+++ b/src/js/search-modal-core.js
@@ -1,0 +1,188 @@
+// search-modal-core.js
+// Funciones base reutilizables para el modal de búsqueda
+
+// Endpoints para obtener la lista de ítems
+const API_URL_JSON = 'https://api.datawars2.ie/gw2/v1/items/json?fields=id,name_es';
+const API_URL_CSV = 'https://api.datawars2.ie/gw2/v1/items/csv?fields=buy_price,sell_price,buy_quantity,sell_quantity,last_updated,1d_buy_sold,1d_sell_sold,2d_buy_sold,2d_sell_sold,7d_buy_sold,7d_sell_sold,1m_buy_sold,1m_sell_sold';
+const GW2_API_ITEMS = 'https://api.guildwars2.com/v2/items?ids=';
+
+function initSearchModal(options = {}) {
+  const {
+    onSelect = function(id) {},
+    formatPrice = null,
+    useSuggestions = false
+  } = options;
+
+  const searchInput = document.getElementById('modal-search-input');
+  const suggestionsEl = document.getElementById('modal-suggestions');
+  const resultsEl = document.getElementById('modal-results');
+  const loader = document.getElementById('modal-loader');
+  const errorMessage = document.getElementById('modal-error-message');
+
+  let allItems = [];
+  const iconCache = {};
+  const rarityCache = {};
+
+  function showLoader(show) {
+    if (loader) loader.style.display = show ? 'block' : 'none';
+  }
+  function showError(msg) {
+    if (!errorMessage) return;
+    errorMessage.textContent = msg;
+    errorMessage.style.display = 'block';
+  }
+  function hideError() {
+    if (errorMessage) errorMessage.style.display = 'none';
+  }
+
+  async function fetchAllItems() {
+    const cached = sessionStorage.getItem('itemList');
+    if (cached) {
+      allItems = JSON.parse(cached);
+      return;
+    }
+    showLoader(true);
+    hideError();
+    try {
+      const resJson = await fetch(API_URL_JSON);
+      const itemsJson = await resJson.json();
+      const resCsv = await fetch(API_URL_CSV);
+      const csvText = await resCsv.text();
+      const lines = csvText.trim().split('\n');
+      const headers = lines[0].split(',');
+      const itemsCsv = lines.slice(1).map(line => {
+        const values = line.split(',');
+        const obj = {};
+        headers.forEach((h, i) => {
+          if (h === 'last_updated') {
+            obj[h] = values[i] || '-';
+          } else if (h === 'buy_price' || h === 'sell_price') {
+            obj[h] = values[i] !== '' ? parseInt(values[i], 10) : null;
+          } else {
+            obj[h] = values[i] !== '' ? parseInt(values[i], 10) : null;
+          }
+        });
+        return obj;
+      });
+      const csvById = {};
+      itemsCsv.forEach(item => { csvById[Number(item.id)] = item; });
+      allItems = itemsJson.map(item => ({
+        ...item,
+        ...(csvById[Number(item.id)] || {})
+      }));
+      sessionStorage.setItem('itemList', JSON.stringify(allItems));
+    } catch (e) {
+      showError('No se pudieron cargar los ítems.');
+    } finally {
+      showLoader(false);
+    }
+  }
+
+  function renderSuggestions(matches) {
+    if (!useSuggestions) {
+      if (suggestionsEl) {
+        suggestionsEl.innerHTML = '';
+        suggestionsEl.style.display = 'none';
+      }
+      return;
+    }
+    if (!suggestionsEl) return;
+    suggestionsEl.innerHTML = '';
+    if (!matches.length) {
+      suggestionsEl.style.display = 'none';
+      return;
+    }
+    const frag = document.createDocumentFragment();
+    matches.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item.name_es;
+      li.onclick = () => onSelect(item.id);
+      frag.appendChild(li);
+    });
+    suggestionsEl.appendChild(frag);
+    suggestionsEl.style.display = 'block';
+  }
+
+  function renderResults(items, showNoResults = false) {
+    if (!resultsEl) return;
+    resultsEl.innerHTML = '';
+    if (!items.length && showNoResults) {
+      resultsEl.innerHTML = '<div class="error-message">No se encontraron ítems.</div>';
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    items.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'item-card';
+      card.onclick = (e) => onSelect(item.id, e);
+      const rarityClass = typeof getRarityClass === 'function'
+          ? getRarityClass(rarityCache[item.id])
+          : '';
+      const buy = formatPrice ? formatPrice(item.buy_price) : (item.buy_price || 0);
+      const sell = formatPrice ? formatPrice(item.sell_price) : (item.sell_price || 0);
+      card.innerHTML = `
+      <img src="${iconCache[item.id] || ''}" alt=""/>
+      <div class="item-name ${rarityClass}">${item.name_es}</div>
+      <div class="item-price" style="display:none;">Compra: ${buy} | Venta: ${sell}</div>
+    `;
+      fragment.appendChild(card);
+    });
+    resultsEl.appendChild(fragment);
+  }
+
+  function debounce(fn, ms) {
+    let timer;
+    return function(...args) {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), ms);
+    };
+  }
+
+  async function fetchIconsFor(ids) {
+    if (!ids.length) return;
+    try {
+      const res = await fetch(GW2_API_ITEMS + ids.join(','));
+      const data = await res.json();
+      data.forEach(item => {
+        iconCache[item.id] = item.icon;
+        rarityCache[item.id] = item.rarity;
+      });
+    } catch {}
+  }
+
+  function normalizeStr(str) {
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', debounce(async function() {
+      const value = this.value.trim().toLowerCase();
+      if (value.length < 3) {
+        if (useSuggestions && suggestionsEl) suggestionsEl.style.display = 'none';
+        if (resultsEl) resultsEl.innerHTML = '';
+        return;
+      }
+      const normalValue = normalizeStr(value);
+      let matches = allItems.filter(item => item.name_es && normalizeStr(item.name_es).includes(normalValue));
+      matches = matches.slice(0, 30);
+      const missingIcons = matches.filter(i => !iconCache[i.id]).map(i => i.id);
+      if (missingIcons.length) await fetchIconsFor(missingIcons);
+      renderSuggestions(matches);
+      renderResults(matches, true);
+    }, 250));
+  }
+
+  (async function init() {
+    await fetchAllItems();
+    renderResults([]);
+  })();
+}
+
+if (typeof window !== 'undefined') {
+  window.initSearchModal = initSearchModal;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports.initSearchModal = initSearchModal;
+}
+

--- a/src/js/search-modal.js
+++ b/src/js/search-modal.js
@@ -1,152 +1,25 @@
-// Versión modal del buscador (adaptada de index-2.js)
-const API_URL_JSON = 'https://api.datawars2.ie/gw2/v1/items/json?fields=id,name_es';
-const API_URL_CSV = 'https://api.datawars2.ie/gw2/v1/items/csv?fields=buy_price,sell_price,buy_quantity,sell_quantity,last_updated,1d_buy_sold,1d_sell_sold,2d_buy_sold,2d_sell_sold,7d_buy_sold,7d_sell_sold,1m_buy_sold,1m_sell_sold';
-const GW2_API_ITEMS = 'https://api.guildwars2.com/v2/items?ids=';
+// search-modal.js
+// Carga el modal de búsqueda estándar utilizando search-modal-core
 
-// Elementos del modal (IDs únicos para evitar conflicto)
-const searchInput = document.getElementById('modal-search-input');
-const suggestionsEl = document.getElementById('modal-suggestions');
-const resultsEl = document.getElementById('modal-results');
-const loader = document.getElementById('modal-loader');
-const errorMessage = document.getElementById('modal-error-message');
-
-let allItems = [];
-let iconCache = {};
-let rarityCache = {};
-
-function showLoader(show) {
-  loader.style.display = show ? 'block' : 'none';
-}
-function showError(msg) {
-  errorMessage.textContent = msg;
-  errorMessage.style.display = 'block';
-}
-function hideError() {
-  errorMessage.style.display = 'none';
-}
-
-async function fetchAllItems() {
-  const cached = sessionStorage.getItem('itemList');
-  if (cached) {
-    allItems = JSON.parse(cached);
-    return;
-  }
-  showLoader(true);
-  hideError();
-  try {
-    const resJson = await fetch(API_URL_JSON);
-    const itemsJson = await resJson.json();
-    const resCsv = await fetch(API_URL_CSV);
-    const csvText = await resCsv.text();
-    const lines = csvText.trim().split('\n');
-    const headers = lines[0].split(',');
-    const itemsCsv = lines.slice(1).map(line => {
-      const values = line.split(',');
-      const obj = {};
-      headers.forEach((h, i) => {
-        if (h === 'last_updated') {
-          obj[h] = values[i] || '-';
-        } else if (h === 'buy_price' || h === 'sell_price') {
-          obj[h] = values[i] !== '' ? parseInt(values[i], 10) : null;
-        } else {
-          obj[h] = values[i] !== '' ? parseInt(values[i], 10) : null;
-        }
+(function() {
+  function start() {
+    if (typeof initSearchModal === 'function') {
+      initSearchModal({
+        onSelect: function(id) {
+          window.location.href = `item.html?id=${id}`;
+        },
+        formatPrice: window.formatGoldColored,
+        useSuggestions: false
       });
-      return obj;
-    });
-    const csvById = {};
-    itemsCsv.forEach(item => { csvById[Number(item.id)] = item; });
-    allItems = itemsJson.map(item => ({
-      ...item,
-      ...(csvById[Number(item.id)] || {})
-    }));
-    sessionStorage.setItem('itemList', JSON.stringify(allItems));
-  } catch (e) {
-    showError('No se pudieron cargar los ítems.');
-  } finally {
-    showLoader(false);
+    }
   }
-}
 
-function renderSuggestions(matches) {
-  // Siempre oculta la lista de sugerencias en el modal
-  suggestionsEl.innerHTML = '';
-  suggestionsEl.style.display = 'none';
-}
-
-function renderResults(items, showNoResults = false) {
-  resultsEl.innerHTML = '';
-  if (!items.length && showNoResults) {
-    resultsEl.innerHTML = '<div class="error-message">No se encontraron ítems.</div>';
-    return;
+  if (typeof initSearchModal === 'undefined') {
+    var script = document.createElement('script');
+    script.src = 'dist/search-modal-core.min.js';
+    script.onload = start;
+    document.body.appendChild(script);
+  } else {
+    start();
   }
-  const fragment = document.createDocumentFragment();
-  items.forEach(item => {
-    const card = document.createElement('div');
-    card.className = 'item-card';
-    card.onclick = () => selectItem(item.id);
-    const rarityClass = typeof getRarityClass === 'function'
-        ? getRarityClass(rarityCache[item.id])
-        : '';
-    card.innerHTML = `
-      <img src="${iconCache[item.id] || ''}" alt=""/>
-      <div class="item-name ${rarityClass}">${item.name_es}</div>
-      <div class="item-price" style="display:none;">Compra: ${formatGoldColored(item.buy_price)} | Venta: ${formatGoldColored(item.sell_price)}</div>
-    `;
-    fragment.appendChild(card);
-  });
-  resultsEl.appendChild(fragment);
-}
-
-
-
-function selectItem(id) {
-  window.location.href = `item.html?id=${id}`;
-}
-
-function debounce(fn, ms) {
-  let timer;
-  return function(...args) {
-    clearTimeout(timer);
-    timer = setTimeout(() => fn.apply(this, args), ms);
-  };
-}
-
-async function fetchIconsFor(ids) {
-  if (!ids.length) return;
-  try {
-    const res = await fetch(GW2_API_ITEMS + ids.join(','));
-    const data = await res.json();
-    data.forEach(item => {
-      iconCache[item.id] = item.icon;
-      rarityCache[item.id] = item.rarity;
-    });
-  } catch {}
-}
-
-// --- Eventos ---
-// Helper para eliminar acentos y normalizar
-function normalizeStr(str) {
-  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-}
-
-searchInput.addEventListener('input', debounce(async function(e) {
-  const value = this.value.trim().toLowerCase();
-  if (value.length < 3) {
-    suggestionsEl.style.display = 'none';
-    renderResults([]);
-    return;
-  }
-  const normalValue = normalizeStr(value);
-const matches = allItems.filter(item => item.name_es && normalizeStr(item.name_es).includes(normalValue)).slice(0, 30);
-  const missingIcons = matches.filter(i => !iconCache[i.id]).map(i => i.id);
-  if (missingIcons.length) await fetchIconsFor(missingIcons);
-  renderSuggestions(matches);
-  renderResults(matches, true);
-}, 250));
-
-// --- Inicio ---
-(async function init() {
-  await fetchAllItems();
-  renderResults([]);
 })();


### PR DESCRIPTION
## Summary
- create a reusable `initSearchModal` in `search-modal-core.js`
- load this core from `search-modal.js` and `search-modal-compare-craft.js`
- update HTML pages to load the new bundle when opening the modal

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881298e599883289ee1500134ba5897