### PR TITLE
Add defer attributes to page scripts

### DIFF
--- a/compare-craft.html
+++ b/compare-craft.html
@@ -63,7 +63,7 @@
 
 
   
-  <script src="dist/bundle-utils-1.min.js"></script>
+  <script src="dist/bundle-utils-1.min.js" defer></script>
 
   <!-- Modal del Buscador fuera de .container para igualar a index.html -->
   <div id="search-modal" class="search-modal hidden">
@@ -94,12 +94,12 @@
   });
   </script>
 
-  <script src="dist/item-tabs.min.js"></script>
-  <script src="dist/feedback-modal.min.js"></script>
+  <script src="dist/item-tabs.min.js" defer></script>
+  <script src="dist/feedback-modal.min.js" defer></script>
   <!-- Nuevos módulos separados -->
-  <script type="module" src="dist/items-core.min.js"></script>
-  <script type="module" src="dist/ui-helpers.min.js"></script>
-  <script type="module" src="dist/compare-ui.min.js"></script>
+  <script type="module" src="dist/items-core.min.js" defer></script>
+  <script type="module" src="dist/ui-helpers.min.js" defer></script>
+  <script type="module" src="dist/compare-ui.min.js" defer></script>
 
   <script>
   // Override global de selectItem para integración con el modal en compare-craft
@@ -128,7 +128,7 @@
 };
 
   </script>
-<script src="dist/bundle-auth-nav.min.js"></script>
+<script src="dist/bundle-auth-nav.min.js" defer></script>
 <script>
   // Inicializar autenticación cuando el DOM esté listo
   document.addEventListener('DOMContentLoaded', function() {
@@ -138,9 +138,9 @@
   });
 </script>
 
-<script src="dist/storageUtils.min.js"></script>
+<script src="dist/storageUtils.min.js" defer></script>
 <!-- Manejadores de comparativa (guardar comparativa) -->
-<script src="dist/compareHandlers.min.js"></script>
+<script src="dist/compareHandlers.min.js" defer></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     if (window.comparativa &&

--- a/dones.html
+++ b/dones.html
@@ -76,11 +76,11 @@
     </main>
   </div>
 
-  <script src="dist/bundle-utils-1.min.js"></script>
-  <script src="dist/bundle-dones.min.js"></script>
-  <script src="dist/bundle-legendary.min.js"></script>
-  <script src="dist/dones.min.js"></script>
-  <script src="dist/bundle-auth-nav.min.js"></script>
+  <script src="dist/bundle-utils-1.min.js" defer></script>
+  <script src="dist/bundle-dones.min.js" defer></script>
+  <script src="dist/bundle-legendary.min.js" defer></script>
+  <script src="dist/dones.min.js" defer></script>
+  <script src="dist/bundle-auth-nav.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -90,6 +90,6 @@
     });
   </script>
   
-  <script src="dist/feedback-modal.min.js"></script>
+  <script src="dist/feedback-modal.min.js" defer></script>
 </body>
 </html>

--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -162,7 +162,7 @@
 <!-- fin EXTRAS -->
     </main>
   </div>
-  <script src="dist/bundle-utils-1.min.js"></script>
+  <script src="dist/bundle-utils-1.min.js" defer></script>
   <script src="dist/bundle-fractales.min.js"></script>
   <script>
     // Tabs visuales como en item.html
@@ -209,7 +209,7 @@
 
     renderTodo();
   </script>
-  <script src="dist/bundle-auth-nav.min.js"></script>
+  <script src="dist/bundle-auth-nav.min.js" defer></script>
   <script>
     // Inicializar autenticación cuando el DOM esté listo
     document.addEventListener('DOMContentLoaded', function() {
@@ -219,6 +219,6 @@
     });
   </script>
   
-  <script src="dist/feedback-modal.min.js"></script>
+  <script src="dist/feedback-modal.min.js" defer></script>
 </body>
 </html>

--- a/item.html
+++ b/item.html
@@ -76,7 +76,7 @@
       <div id="modal-results" class="item-list"></div>
     </div>
   </div>
-  <script src="dist/bundle-utils-1.min.js"></script>
+  <script src="dist/bundle-utils-1.min.js" defer></script>
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     const openBtn = document.getElementById('open-search-modal');
@@ -94,7 +94,7 @@
   });
   </script>
 
-<script src="dist/bundle-auth-nav.min.js"></script>
+<script src="dist/bundle-auth-nav.min.js" defer></script>
 <script>
   // Inicializar autenticación cuando el DOM esté listo
   document.addEventListener('DOMContentLoaded', function() {
@@ -122,17 +122,17 @@
   });
 </script>
 
-<script src="dist/feedback-modal.min.js"></script>
-<script src="dist/item-tabs.min.js"></script>
-<script src="dist/services/recipeService.min.js"></script>
-<script src="dist/utils/recipeUtils.min.js"></script>
-<script src="dist/item-mejores.min.js"></script>
-<script src="dist/itemHandlers.min.js"></script>
-<script src="dist/storageUtils.min.js"></script>
-<script type="module" src="dist/ui-helpers.min.js"></script>
-<script type="module" src="dist/item-ui.min.js"></script>
-<script type="module" src="dist/items-core.min.js"></script>
-<script type="module" src="dist/item-loader.min.js"></script>
+<script src="dist/feedback-modal.min.js" defer></script>
+<script src="dist/item-tabs.min.js" defer></script>
+<script src="dist/services/recipeService.min.js" defer></script>
+<script src="dist/utils/recipeUtils.min.js" defer></script>
+<script src="dist/item-mejores.min.js" defer></script>
+<script src="dist/itemHandlers.min.js" defer></script>
+<script src="dist/storageUtils.min.js" defer></script>
+<script type="module" src="dist/ui-helpers.min.js" defer></script>
+<script type="module" src="dist/item-ui.min.js" defer></script>
+<script type="module" src="dist/items-core.min.js" defer></script>
+<script type="module" src="dist/item-loader.min.js" defer></script>
   
   <!-- Inicialización -->
   <script>

--- a/leg-craft.html
+++ b/leg-craft.html
@@ -132,9 +132,9 @@
     </div>
   </div>
 
-  <script src="dist/bundle-utils-1.min.js"></script>
-  <script src="dist/bundle-auth-nav.min.js"></script>
-  <script src="dist/bundle-legendary.min.js"></script>
+  <script src="dist/bundle-utils-1.min.js" defer></script>
+  <script src="dist/bundle-auth-nav.min.js" defer></script>
+  <script src="dist/bundle-legendary.min.js" defer></script>
   <!-- Ensure the first-generation tree displays data by default -->
   <script>
     document.addEventListener('DOMContentLoaded', function () {
@@ -152,8 +152,8 @@
     });
   </script>
   
-  <script src="dist/leg-craft-tabs.min.js"></script>
+  <script src="dist/leg-craft-tabs.min.js" defer></script>
   
-  <script src="dist/feedback-modal.min.js"></script>
+  <script src="dist/feedback-modal.min.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- defer loading of JS bundles on key pages
- keep bundle-fractales eager since inline script depends on it

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817b42dddc8328b092e7aa609a1e0e