### PR TITLE
Update login gating and logout cleanup

### DIFF
--- a/dist/bundle-auth-nav.min.js
+++ b/dist/bundle-auth-nav.min.js
@@ -83,6 +83,7 @@ function loginWithFacebook() {
 function logout() {
     currentUser = null;
     localStorage.removeItem('user');
+    localStorage.removeItem('auth_token');
     deleteAuthToken();
     updateAuthUI();
     window.location.href = 'index.html';

--- a/dist/itemHandlers.min.js
+++ b/dist/itemHandlers.min.js
@@ -14,7 +14,7 @@ function initSaveItemHandler() {
     if (!saveButton) return;
     
     // Mostrar/ocultar según autenticación
-    const user = JSON.parse(localStorage.getItem('user') || 'null');
+    const user = window.Auth && window.Auth.currentUser;
     if (!user) {
         saveButton.style.display = 'none';
         return;

--- a/item.html
+++ b/item.html
@@ -32,9 +32,9 @@
     <!-- Botones de navegación -->
     <nav class="item-tabs-nav">
       <button class="item-tab-btn" data-tab="info-item">Crafteo</button>
-      <button class="item-tab-btn" data-tab="resumen-mercado">Resumen Mercado</button>
-      <button class="item-tab-btn" data-tab="tab-mejores-horas-content">Actividad Reciente</button>
-      <button class="item-tab-btn" id="btn-guardar-item">Guardar ítem</button>
+      <button class="item-tab-btn" data-tab="resumen-mercado" data-requires-login="true">Resumen Mercado</button>
+      <button class="item-tab-btn" data-tab="tab-mejores-horas-content" data-requires-login="true">Actividad Reciente</button>
+      <button class="item-tab-btn" id="btn-guardar-item" data-requires-login="true">Guardar ítem</button>
     </nav>
     
     <div class="container">
@@ -45,8 +45,8 @@
         <div id="seccion-comparativa"></div>
         <div id="seccion-crafting"></div>
       </div>
-      <div id="resumen-mercado" style="display:none;"></div>
-      <div id="tab-mejores-horas-content" style="display:none;">
+      <div id="resumen-mercado" style="display:none;" data-requires-login="true"></div>
+      <div id="tab-mejores-horas-content" style="display:none;" data-requires-login="true">
         <div class="card">
           <h3>Ventas y Compras por Hora</h3>
           <canvas id="ventas-compras-chart" height="120"></canvas>
@@ -100,24 +100,6 @@
   document.addEventListener('DOMContentLoaded', function() {
     if (window.Auth && typeof window.Auth.initAuth === 'function') {
       window.Auth.initAuth();
-    }
-  });
-</script>
-<script>
-  // Ocultar pestañas de mercado y actividad si no hay usuario autenticado
-  document.addEventListener('DOMContentLoaded', function() {
-    const loggedIn = !!localStorage.getItem('auth_token');
-    if (!loggedIn) {
-      document.querySelectorAll(
-        '.item-tab-btn[data-tab="resumen-mercado"],\
-        .item-tab-btn[data-tab="tab-mejores-horas-content"]'
-      ).forEach(el => el.style.display = 'none');
-
-      const resumen = document.getElementById('resumen-mercado');
-      if (resumen) resumen.style.display = 'none';
-
-      const mejores = document.getElementById('tab-mejores-horas-content');
-      if (mejores) mejores.style.display = 'none';
     }
   });
 </script>

--- a/src/js/bundle-auth-nav.js
+++ b/src/js/bundle-auth-nav.js
@@ -94,6 +94,7 @@ function loginWithFacebook() {
 function logout() {
     currentUser = null;
     localStorage.removeItem('user');
+    localStorage.removeItem('auth_token');
     deleteAuthToken();
     updateAuthUI();
     window.location.href = 'index.html';

--- a/src/js/itemHandlers.js
+++ b/src/js/itemHandlers.js
@@ -14,7 +14,7 @@ function initSaveItemHandler() {
     if (!saveButton) return;
     
     // Mostrar/ocultar según autenticación
-    const user = JSON.parse(localStorage.getItem('user') || 'null');
+    const user = window.Auth && window.Auth.currentUser;
     if (!user) {
         saveButton.style.display = 'none';
         return;


### PR DESCRIPTION
## Summary
- mark market and activity tabs as requiring login
- remove inline login check from *item.html*
- hide "Guardar ítem" button unless `window.Auth.currentUser` is set
- clear old auth token on logout

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818dd7c140832881a06abcae82815d