### PR TITLE
Add PHP backend with OAuth and API endpoints

### DIFF
--- a/backend/api/comparisons.php
+++ b/backend/api/comparisons.php
@@ -1,0 +1,37 @@
+<?php
+require_once __DIR__.'/../session.php';
+header('Content-Type: application/json');
+
+$user = require_session();
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $stmt = $pdo->prepare('SELECT id, item_left, item_right FROM comparisons WHERE user_id=?');
+    $stmt->execute([$user['id']]);
+    echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+} elseif ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $left = $data['item_left'] ?? null;
+    $right = $data['item_right'] ?? null;
+    if (!$left || !$right) {
+        http_response_code(400);
+        echo json_encode(['error' => 'item_left and item_right required']);
+        exit;
+    }
+    $stmt = $pdo->prepare('INSERT INTO comparisons (user_id, item_left, item_right) VALUES (?, ?, ?)');
+    $stmt->execute([$user['id'], $left, $right]);
+    echo json_encode(['success' => true, 'id' => $pdo->lastInsertId()]);
+} elseif ($method === 'DELETE') {
+    $id = $_GET['id'] ?? null;
+    if (!$id) {
+        http_response_code(400);
+        echo json_encode(['error' => 'id required']);
+        exit;
+    }
+    $stmt = $pdo->prepare('DELETE FROM comparisons WHERE user_id=? AND id=?');
+    $stmt->execute([$user['id'], $id]);
+    echo json_encode(['success' => true]);
+} else {
+    http_response_code(405);
+}
+?>

--- a/backend/api/favorites.php
+++ b/backend/api/favorites.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__.'/../session.php';
+header('Content-Type: application/json');
+
+$user = require_session();
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $stmt = $pdo->prepare('SELECT item_id FROM favorites WHERE user_id=?');
+    $stmt->execute([$user['id']]);
+    echo json_encode($stmt->fetchAll(PDO::FETCH_COLUMN));
+} elseif ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $item = $data['item_id'] ?? null;
+    if (!$item) {
+        http_response_code(400);
+        echo json_encode(['error' => 'item_id required']);
+        exit;
+    }
+    $stmt = $pdo->prepare('INSERT IGNORE INTO favorites (user_id, item_id) VALUES (?, ?)');
+    $stmt->execute([$user['id'], $item]);
+    echo json_encode(['success' => true]);
+} elseif ($method === 'DELETE') {
+    $item = $_GET['item_id'] ?? null;
+    if (!$item) {
+        http_response_code(400);
+        echo json_encode(['error' => 'item_id required']);
+        exit;
+    }
+    $stmt = $pdo->prepare('DELETE FROM favorites WHERE user_id=? AND item_id=?');
+    $stmt->execute([$user['id'], $item]);
+    echo json_encode(['success' => true]);
+} else {
+    http_response_code(405);
+}
+?>

--- a/backend/api/user.php
+++ b/backend/api/user.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__.'/../session.php';
+header('Content-Type: application/json');
+
+$user = require_session();
+
+echo json_encode([
+    'id' => $user['id'],
+    'email' => $user['email'],
+    'name' => $user['name'],
+    'avatar' => $user['avatar'],
+    'provider' => $user['oauth_provider']
+]);
+?>

--- a/backend/auth.php
+++ b/backend/auth.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+$provider = $_GET['provider'] ?? '';
+$state = bin2hex(random_bytes(16));
+$_SESSION['oauth_state'] = $state;
+$_SESSION['oauth_provider'] = $provider;
+$redirect = getenv('OAUTH_REDIRECT_URI') ?: 'http://localhost/backend/oauth_callback.php';
+
+switch ($provider) {
+    case 'google':
+        $params = [
+            'client_id' => getenv('GOOGLE_CLIENT_ID'),
+            'redirect_uri' => $redirect,
+            'response_type' => 'code',
+            'scope' => 'profile email',
+            'state' => $state
+        ];
+        $url = 'https://accounts.google.com/o/oauth2/v2/auth?'.http_build_query($params);
+        header('Location: '.$url);
+        exit;
+    case 'discord':
+        $params = [
+            'client_id' => getenv('DISCORD_CLIENT_ID'),
+            'redirect_uri' => $redirect,
+            'response_type' => 'code',
+            'scope' => 'identify email',
+            'state' => $state
+        ];
+        $url = 'https://discord.com/api/oauth2/authorize?'.http_build_query($params);
+        header('Location: '.$url);
+        exit;
+    default:
+        http_response_code(400);
+        echo 'Unknown provider';
+}
+?>

--- a/backend/config.php
+++ b/backend/config.php
@@ -1,0 +1,16 @@
+<?php
+// Database configuration
+$DB_HOST = getenv('DB_HOST') ?: 'localhost';
+$DB_NAME = getenv('DB_NAME') ?: 'gw2db';
+$DB_USER = getenv('DB_USER') ?: 'user';
+$DB_PASS = getenv('DB_PASS') ?: 'password';
+
+try {
+    $pdo = new PDO("mysql:host=$DB_HOST;dbname=$DB_NAME;charset=utf8mb4", $DB_USER, $DB_PASS);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database connection failed']);
+    exit;
+}
+?>

--- a/backend/oauth_callback.php
+++ b/backend/oauth_callback.php
@@ -1,0 +1,95 @@
+<?php
+require_once __DIR__.'/config.php';
+session_start();
+header('Content-Type: text/html');
+
+if (empty($_GET['state']) || $_GET['state'] !== ($_SESSION['oauth_state'] ?? '')) {
+    http_response_code(400);
+    echo 'Invalid state';
+    exit;
+}
+
+$provider = $_SESSION['oauth_provider'] ?? '';
+$code = $_GET['code'] ?? '';
+$redirect = getenv('OAUTH_REDIRECT_URI') ?: 'http://localhost/backend/oauth_callback.php';
+
+function post($url, $params) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: application/json']);
+    $resp = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($resp, true);
+}
+
+function get_json($url, $token) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer '.$token]);
+    $resp = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($resp, true);
+}
+
+switch ($provider) {
+    case 'google':
+        $token = post('https://oauth2.googleapis.com/token', [
+            'code' => $code,
+            'client_id' => getenv('GOOGLE_CLIENT_ID'),
+            'client_secret' => getenv('GOOGLE_CLIENT_SECRET'),
+            'redirect_uri' => $redirect,
+            'grant_type' => 'authorization_code'
+        ]);
+        $info = get_json('https://www.googleapis.com/oauth2/v2/userinfo', $token['access_token']);
+        $oauth_id = $info['id'] ?? null;
+        $email = $info['email'] ?? null;
+        $name = $info['name'] ?? null;
+        $avatar = $info['picture'] ?? null;
+        break;
+    case 'discord':
+        $token = post('https://discord.com/api/oauth2/token', [
+            'code' => $code,
+            'client_id' => getenv('DISCORD_CLIENT_ID'),
+            'client_secret' => getenv('DISCORD_CLIENT_SECRET'),
+            'redirect_uri' => $redirect,
+            'grant_type' => 'authorization_code'
+        ]);
+        $info = get_json('https://discord.com/api/users/@me', $token['access_token']);
+        $oauth_id = $info['id'] ?? null;
+        $email = $info['email'] ?? null;
+        $name = $info['username'] ?? null;
+        $avatar = isset($info['avatar']) ? 'https://cdn.discordapp.com/avatars/'.$info['id'].'/'.$info['avatar'].'.png' : null;
+        break;
+    default:
+        http_response_code(400);
+        echo 'Unknown provider';
+        exit;
+}
+
+if (!$oauth_id) {
+    http_response_code(400);
+    echo 'Invalid OAuth response';
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT id FROM users WHERE oauth_provider=? AND oauth_id=?');
+$stmt->execute([$provider, $oauth_id]);
+$user_id = $stmt->fetchColumn();
+if ($user_id) {
+    $stmt = $pdo->prepare('UPDATE users SET email=?, name=?, avatar=? WHERE id=?');
+    $stmt->execute([$email, $name, $avatar, $user_id]);
+} else {
+    $stmt = $pdo->prepare('INSERT INTO users (oauth_provider, oauth_id, email, name, avatar) VALUES (?, ?, ?, ?, ?)');
+    $stmt->execute([$provider, $oauth_id, $email, $name, $avatar]);
+    $user_id = $pdo->lastInsertId();
+}
+
+$session_id = bin2hex(random_bytes(32));
+$stmt = $pdo->prepare('INSERT INTO sessions (id, user_id) VALUES (?, ?)');
+$stmt->execute([$session_id, $user_id]);
+setcookie('session_id', $session_id, time()+86400*30, '/', '', false, true);
+
+header('Location: /cuenta.html');
+?>

--- a/backend/session.php
+++ b/backend/session.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__.'/config.php';
+
+function require_session() {
+    global $pdo;
+    if (empty($_COOKIE['session_id'])) {
+        http_response_code(401);
+        echo json_encode(['error' => 'No session']);
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT users.* FROM sessions JOIN users ON sessions.user_id=users.id WHERE sessions.id=?');
+    $stmt->execute([$_COOKIE['session_id']]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid session']);
+        exit;
+    }
+    return $user;
+}
+?>

--- a/backend/setup.sql
+++ b/backend/setup.sql
@@ -1,0 +1,36 @@
+-- SQL schema for application
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    oauth_provider VARCHAR(20) NOT NULL,
+    oauth_id VARCHAR(100) NOT NULL,
+    email VARCHAR(255) DEFAULT NULL,
+    name VARCHAR(255) DEFAULT NULL,
+    avatar VARCHAR(255) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY (oauth_provider, oauth_id)
+);
+
+CREATE TABLE sessions (
+    id VARCHAR(64) PRIMARY KEY,
+    user_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE favorites (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    item_id VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY (user_id, item_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE comparisons (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    item_left VARCHAR(50) NOT NULL,
+    item_right VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add backend folder with PDO config and SQL schema
- implement OAuth login using Google or Discord
- create REST API endpoints for user info, favorites and comparisons

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881aced341c8328bdd0212f027d680c