### PR TITLE
Update links without .html

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -39,7 +39,7 @@
                 const resp = await fetch('backend/api/user.php');
                 if (resp.ok) {
                     const urlParams = new URLSearchParams(window.location.search);
-                    const redirect = urlParams.get('redirect') || 'cuenta.html';
+                    const redirect = urlParams.get('redirect') || '/cuenta';
                     window.location.href = redirect;
                 } else {
                     document.getElementById('status').textContent = 'No hay sesión activa.';

--- a/backend/oauth_callback.php
+++ b/backend/oauth_callback.php
@@ -91,5 +91,5 @@ $stmt = $pdo->prepare('INSERT INTO sessions (id, user_id) VALUES (?, ?)');
 $stmt->execute([$session_id, $user_id]);
 setcookie('session_id', $session_id, time()+86400*30, '/', '', false, true);
 
-header('Location: /cuenta.html');
+header('Location: /cuenta');
 ?>

--- a/dist/bundle-auth-nav.min.js
+++ b/dist/bundle-auth-nav.min.js
@@ -2,7 +2,7 @@
 
 // ==== auth.js content ====
 const GOOGLE_CLIENT_ID = '943692746860-a4k9lfb5h9ds4o3umb7juf4rjce8afqf.apps.googleusercontent.com';
-const GOOGLE_REDIRECT_URI = `${window.location.origin}/auth.html`;
+const GOOGLE_REDIRECT_URI = `${window.location.origin}/auth`;
 
 let currentUser = JSON.parse(localStorage.getItem('user')) || null;
 function setAuthToken(t){document.cookie=`auth_token=${t}; path=/`}
@@ -83,12 +83,12 @@ function logout() {
     localStorage.removeItem('auth_token');
     deleteAuthToken();
     updateAuthUI();
-    window.location.href = 'index.html';
+    window.location.href = '/';
 }
 
 function requireAuth() {
     if (!currentUser) {
-        window.location.href = 'auth.html?redirect=' + encodeURIComponent(window.location.pathname);
+        window.location.href = '/auth?redirect=' + encodeURIComponent(window.location.pathname);
         return false;
     }
     return true;
@@ -152,11 +152,11 @@ const ThemeManager = {
 const navigationData = {
     menuItems: [
         { text: 'Inicio', href: '/', target: 'tab-detalles', class: '' },
-        { text: 'Dones', href: 'dones.html', target: 'tab-crafteo', class: '' },
-        { text: 'Comparativa', href: 'compare-craft.html', target: 'tab-comparativa', class: '', requiresLogin: true },
-        { text: 'Fractales', href: 'fractales-gold.html', target: 'tab-fractales', class: '', requiresLogin: true },
-        { text: 'Legendarias', href: 'leg-craft.html', target: 'tab-leg-craft', class: '' },
-        { text: 'Forja Mística', href: 'forja-mistica.html', target: 'tab-forja-mistica', class: '' }
+        { text: 'Dones', href: '/dones', target: 'tab-crafteo', class: '' },
+        { text: 'Comparativa', href: '/compare-craft', target: 'tab-comparativa', class: '', requiresLogin: true },
+        { text: 'Fractales', href: '/fractales-gold', target: 'tab-fractales', class: '', requiresLogin: true },
+        { text: 'Legendarias', href: '/leg-craft', target: 'tab-leg-craft', class: '' },
+        { text: 'Forja Mística', href: '/forja-mistica', target: 'tab-forja-mistica', class: '' }
     ],
     rightMenuItems: [
         {
@@ -178,7 +178,7 @@ const navigationData = {
             id: 'loginBtn',
             onClick: (e) => {
                 e.preventDefault();
-                window.location.href = 'login.html';
+                window.location.href = '/login';
             }
         },
         {
@@ -242,7 +242,7 @@ function showAuthOptions() {
                 <button id="discord-login-btn" class="auth-btn discord-btn">
                     <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/discordjs/discordjs-original.svg" alt="discord"> Discord
                 </button>
-                <a href="login.html" class="auth-classic-link">¿Prefieres iniciar sesión clásico?</a>
+                <a href="/login" class="auth-classic-link">¿Prefieres iniciar sesión clásico?</a>
                 <button onclick="document.getElementById('auth-modal').remove()" class="auth-cancel-btn">Cancelar</button>
             </div>`;
         document.body.appendChild(modal);
@@ -270,7 +270,7 @@ function showAccountModal() {
             <img src="${user.picture || 'https://via.placeholder.com/64'}" class="account-avatar" alt="avatar">
             <div class="account-name">${user.name || 'Usuario'}</div>
             <div class="account-email">${user.email || ''}</div>
-            <a href="cuenta.html" class="account-link">Mi Cuenta</a>
+            <a href="/cuenta" class="account-link">Mi Cuenta</a>
             <button onclick="window.Auth && window.Auth.logout && window.Auth.logout()" class="logout-btn">Cerrar sesión</button>
             <button class="close-account-btn">Cerrar</button>
         </div>`;

--- a/dist/bundle-legendary.min.js
+++ b/dist/bundle-legendary.min.js
@@ -3120,7 +3120,7 @@ class LegendaryCraftingBase {
           ${hasChildren ? `<button class="toggle-children" data-expanded="${isExpanded}">${isExpanded ? '−' : '+'}</button>` : '<div style="width: 24px;"></div>'}
           <img class="item-icon" src="${iconUrl}" alt="${ingredient.name || 'Item'}" title="${ingredient.name || 'Item'}" onerror="this.onerror=null;this.src='${this._getDefaultIconUrl()}';">
           <div class="item-name ${rarityClass}">
-            ${isLegendary ? `<a href="item.html?id=${ingredient.id}" class="item-link" target="_blank">${ingredient.name || 'Item'}</a>` : (ingredient.name || 'Item')}
+            ${isLegendary ? `<a href="/item?id=${ingredient.id}" class="item-link" target="_blank">${ingredient.name || 'Item'}</a>` : (ingredient.name || 'Item')}
           </div>
           <div class="item-details">
             ${ingredient.count > 1 ? `<span class="item-count">x${ingredient.count}</span>` : ''}

--- a/dist/compare-ui.min.js
+++ b/dist/compare-ui.min.js
@@ -164,7 +164,7 @@ function renderMainItemRow(mainItem, qty, totalBuy, totalSell, totalCrafted) {
   return `
     <tr class="row-bg-main">
       <td class="th-border-left-items"><img src="${mainItem.icon}" width="32"></td>
-      <td><a href="item.html?id=${mainItem.id}" class="item-link ${rarityClass}" target="_blank">${(mainItem.recipe && mainItem.recipe.output_item_count && mainItem.recipe.output_item_count > 1) ? `<span style='color:#a1a1aa;font-size:0.95em;display:block;margin-bottom:2px;'>Receta produce <b>${mainItem.recipe.output_item_count}</b> unidades<br>Profit mostrado es por unidad</span>` : ''}${mainItem.name}</a></td>
+      <td><a href="/item?id=${mainItem.id}" class="item-link ${rarityClass}" target="_blank">${(mainItem.recipe && mainItem.recipe.output_item_count && mainItem.recipe.output_item_count > 1) ? `<span style='color:#a1a1aa;font-size:0.95em;display:block;margin-bottom:2px;'>Receta produce <b>${mainItem.recipe.output_item_count}</b> unidades<br>Profit mostrado es por unidad</span>` : ''}${mainItem.name}</a></td>
       <td>${qty}</td>
       <td class="item-unit-sell">${formatGoldColored(Number(mainItem.sell_price))} <span style="color: #c99b5b">c/u</span></td>
       <td class="item-solo-buy"><div>${formatGoldColored(realTotals.totalBuy)}</div></td>
@@ -236,7 +236,7 @@ function renderRows(ings, nivel = 0, parentId = null, rowGroupIndex = 0, parentE
     return `
       <tr data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} child-of-${parentId}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img src="${ing.icon}" width="32"></td>
-        <td><a href="item.html?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
+        <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
         <td>${ing.countTotal ? (Number.isInteger(ing.countTotal) ? ing.countTotal : ing.countTotal.toFixed(2)) : ing.count}</td>
         <td class="item-unit-sell">${formatGoldColored(ing.sell_price)} <span style="color: #c99b5b">c/u</span></td>
         

--- a/dist/cuenta.min.js
+++ b/dist/cuenta.min.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const user = JSON.parse(localStorage.getItem('user'));
     if (!user) {
         // Redirigir al login si no está autenticado
-        window.location.href = 'login.html';
+        window.location.href = '/login';
         return;
     }
 
@@ -133,7 +133,7 @@ function loadAndDisplayFavoritos() {
         
         // Enlace al ítem (nombre se actualizará tras fetch)
         const link = document.createElement('a');
-        link.href = `item.html?id=${item.id}`;
+        link.href = `/item?id=${item.id}`;
         link.className = 'favorito-link';
         link.textContent = item.nombre || `Cargando...`;
 
@@ -260,7 +260,7 @@ function loadAndDisplayComparativas() {
         const fecha = new Date(comp.timestamp || Date.now()).toLocaleDateString();
 
         const link = document.createElement('a');
-        link.href = `compare-craft.html?ids=${comp.ids.join(',')}`;
+        link.href = `/compare-craft?ids=${comp.ids.join(',')}`;
         link.className = 'favorito-link';
         link.textContent = nombre;
 

--- a/dist/item-ui.min.js
+++ b/dist/item-ui.min.js
@@ -64,7 +64,7 @@ function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentE
     return `
       <tr data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img src="${ing.icon}" width="32"></td>
-        <td><a href="item.html?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
+        <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
         <td>${ing.countTotal || ing.count}</td>
         <td class="item-solo-buy">
           <div>${formatGoldColored(ing.total_buy)}</div>

--- a/dist/search-modal.min.js
+++ b/dist/search-modal.min.js
@@ -105,7 +105,7 @@ function renderResults(items, showNoResults = false) {
 
 
 function selectItem(id) {
-  window.location.href = `item.html?id=${id}`;
+  window.location.href = `/item?id=${id}`;
 }
 
 function debounce(fn, ms) {

--- a/src/js/bundle-legendary.js
+++ b/src/js/bundle-legendary.js
@@ -3121,7 +3121,7 @@ class LegendaryCraftingBase {
           ${hasChildren ? `<button class="toggle-children" data-expanded="${isExpanded}">${isExpanded ? '−' : '+'}</button>` : '<div style="width: 24px;"></div>'}
           <img class="item-icon" src="${iconUrl}" alt="${ingredient.name || 'Item'}" title="${ingredient.name || 'Item'}" onerror="this.onerror=null;this.src='${this._getDefaultIconUrl()}';">
           <div class="item-name ${rarityClass}">
-            ${isLegendary ? `<a href="item.html?id=${ingredient.id}" class="item-link" target="_blank">${ingredient.name || 'Item'}</a>` : (ingredient.name || 'Item')}
+            ${isLegendary ? `<a href="/item?id=${ingredient.id}" class="item-link" target="_blank">${ingredient.name || 'Item'}</a>` : (ingredient.name || 'Item')}
           </div>
           <div class="item-details">
             ${ingredient.count > 1 ? `<span class="item-count">x${ingredient.count}</span>` : ''}

--- a/src/js/compare-ui.js
+++ b/src/js/compare-ui.js
@@ -163,7 +163,7 @@ function renderMainItemRow(mainItem, qty, totalBuy, totalSell, totalCrafted) {
   return `
     <tr class="row-bg-main">
       <td class="th-border-left-items"><img src="${mainItem.icon}" width="32"></td>
-      <td><a href="item.html?id=${mainItem.id}" class="item-link ${rarityClass}" target="_blank">${(mainItem.recipe && mainItem.recipe.output_item_count && mainItem.recipe.output_item_count > 1) ? `<span style='color:#a1a1aa;font-size:0.95em;display:block;margin-bottom:2px;'>Receta produce <b>${mainItem.recipe.output_item_count}</b> unidades<br>Profit mostrado es por unidad</span>` : ''}${mainItem.name}</a></td>
+      <td><a href="/item?id=${mainItem.id}" class="item-link ${rarityClass}" target="_blank">${(mainItem.recipe && mainItem.recipe.output_item_count && mainItem.recipe.output_item_count > 1) ? `<span style='color:#a1a1aa;font-size:0.95em;display:block;margin-bottom:2px;'>Receta produce <b>${mainItem.recipe.output_item_count}</b> unidades<br>Profit mostrado es por unidad</span>` : ''}${mainItem.name}</a></td>
       <td>${qty}</td>
       <td class="item-unit-sell">${formatGoldColored(Number(mainItem.sell_price))} <span style="color: #c99b5b">c/u</span></td>
       <td class="item-solo-buy"><div>${formatGoldColored(realTotals.totalBuy)}</div></td>
@@ -235,7 +235,7 @@ function renderRows(ings, nivel = 0, parentId = null, rowGroupIndex = 0, parentE
     return `
       <tr data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} child-of-${parentId}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img src="${ing.icon}" width="32"></td>
-        <td><a href="item.html?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
+        <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
         <td>${ing.countTotal ? (Number.isInteger(ing.countTotal) ? ing.countTotal : ing.countTotal.toFixed(2)) : ing.count}</td>
         <td class="item-unit-sell">${formatGoldColored(ing.sell_price)} <span style="color: #c99b5b">c/u</span></td>
         

--- a/src/js/cuenta.js
+++ b/src/js/cuenta.js
@@ -6,7 +6,7 @@ if (typeof window.StorageUtils === 'undefined') {
 document.addEventListener('DOMContentLoaded', async function() {
     const resp = await fetch('backend/api/user.php');
     if (!resp.ok) {
-        window.location.href = 'login.html';
+        window.location.href = '/login';
         return;
     }
     const user = await resp.json();
@@ -132,7 +132,7 @@ async function loadAndDisplayFavoritos() {
         
         // Enlace al ítem (nombre se actualizará tras fetch)
         const link = document.createElement('a');
-        link.href = `item.html?id=${item.id}`;
+        link.href = `/item?id=${item.id}`;
         link.className = 'favorito-link';
         link.textContent = item.nombre || `Cargando...`;
 
@@ -250,7 +250,7 @@ async function loadAndDisplayComparativas() {
         const fecha = '';
 
         const link = document.createElement('a');
-        link.href = `compare-craft.html?ids=${comp.ids.join(',')}`;
+        link.href = `/compare-craft?ids=${comp.ids.join(',')}`;
         link.className = 'favorito-link';
         link.textContent = nombre;
 

--- a/src/js/item-ui.js
+++ b/src/js/item-ui.js
@@ -64,7 +64,7 @@ function renderRows(ings, nivel = 1, parentId = null, rowGroupIndex = 0, parentE
     return `
       <tr data-path="${currentPath}" class="${isChild ? `subrow subrow-${nivel} ${extraClass}` : ''} ${rowBgClass}" ${extraStyle}>
         <td class="th-border-left-items" ${indent}><img src="${ing.icon}" width="32"></td>
-        <td><a href="item.html?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
+        <td><a href="/item?id=${ing.id}" class="item-link ${rarityClass}" target="_blank">${ing.name}</a></td>
         <td>${ing.countTotal || ing.count}</td>
         <td class="item-solo-buy">
           <div>${formatGoldColored(ing.total_buy)}</div>

--- a/src/js/search-modal.js
+++ b/src/js/search-modal.js
@@ -6,7 +6,7 @@
     if (typeof initSearchModal === 'function') {
       initSearchModal({
         onSelect: function(id) {
-          window.location.href = `item.html?id=${id}`;
+          window.location.href = `/item?id=${id}`;
         },
         formatPrice: window.formatGoldColored,
         useSuggestions: false


### PR DESCRIPTION
## Summary
- drop .html extensions from redirects and links
- regenerate minified bundles to use new extensionless URLs

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884276e4f4c83289e06c67cca0f5a8a